### PR TITLE
Fix accessor highlighting for sublime build 3143.

### DIFF
--- a/FireCode.tmTheme
+++ b/FireCode.tmTheme
@@ -102,6 +102,17 @@
         </dict>
         <dict>
             <key>name</key>
+            <string>Accessor</string>
+            <key>scope</key>
+            <string>punctuation.accessor</string>
+            <key>settings</key>
+            <dict>
+                <key>foreground</key>
+                <string>#f63249</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
             <string>Storage</string>
             <key>scope</key>
             <string>storage</string>


### PR DESCRIPTION
Sublime build 3143 broke accessor syntax highlighting such as `->` and `::` because it appears that they moved those under the `punctuation.accessor` scope instead of the `keyword` scope.